### PR TITLE
新增白天/黑夜主题切换按钮

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1572,6 +1572,10 @@ spec:
     - group: footer
       label: 页脚
       formSchema:
+        - $formkit: checkbox
+          name: allow_switch_theme
+          label: 是否显示切换主题的按钮
+          value: false
         - $formkit: repeater
           name: social
           label: 社交媒体

--- a/templates/modules/partial/scripts/theme.html
+++ b/templates/modules/partial/scripts/theme.html
@@ -45,9 +45,9 @@
         window.localStorage.setItem('Stellar.theme', newTheme)
 
         const messages = {
-            light: [[#{message.theme_switched.light}]],
-            dark: [[#{message.theme_switched.dark}]],
-            auto: [[#{message.theme_switched.auto}]],
+            light: "#{message.theme_switched.light}",
+            dark: "#{message.theme_switched.dark}",
+            auto: "#{message.theme_switched.auto}",
         }
         hud?.toast?.(messages[newTheme])
     }

--- a/templates/modules/partial/scripts/theme.html
+++ b/templates/modules/partial/scripts/theme.html
@@ -45,9 +45,9 @@
         window.localStorage.setItem('Stellar.theme', newTheme)
 
         const messages = {
-            light: "#{message.theme_switched.light}",
-            dark: "#{message.theme_switched.dark}",
-            auto: "#{message.theme_switched.auto}",
+            light: "[(#{message.theme_switched.light})]",
+            dark: "[(#{message.theme_switched.dark})]",
+            auto: "[(#{message.theme_switched.auto})]",
         }
         hud?.toast?.(messages[newTheme])
     }

--- a/templates/modules/partial/sidebar/footer.html
+++ b/templates/modules/partial/sidebar/footer.html
@@ -1,13 +1,18 @@
 <footer class="footer dis-select">
     <div class="social-wrap">
-        <a th:each="social : ${theme.config.footer.social}" 
-          th:with="is_contain = ${#strings.contains(social.url,'://')}"
-         class="social" 
-         th:title="${social.title}" 
-         th:href="${social.url}" 
-         th:target="${is_contain ? '_blank' : '_self'}" 
-         th::rel="${ is_contain ? 'external nofollow noopener noreferrer' : 'noopener noreferrer'}">
-         <th:block th:if="${not #strings.isEmpty(social.icon)}" th:utext="${social.icon}"></th:block>
+        <a th:each="social : ${theme.config.footer.social}"
+            th:with="is_contain = ${#strings.contains(social.url,'://')}" class="social" th:title="${social.title}"
+            th:href="${social.url}" th:target="${is_contain ? '_blank' : '_self'}"
+            th::rel="${ is_contain ? 'external nofollow noopener noreferrer' : 'noopener noreferrer'}">
+            <th:block th:if="${not #strings.isEmpty(social.icon)}" th:utext="${social.icon}"></th:block>
+        </a>
+        <a class="social" onclick="switchTheme()" th:if="${theme.config.footer.allow_switch_theme}">
+            <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
+                <path
+                    d="M582.4 326.4c-140.8 0-256 115.2-256 256s115.2 256 256 256 256-115.2 256-256-115.2-256-256-256z m0 448c-70.4 0-131.2-36.8-164.8-92.8 12.8 3.2 27.2 4.8 40 4.8 121.6 0 219.2-99.2 219.2-219.2 0-17.6-1.6-35.2-6.4-52.8 60.8 32 102.4 96 102.4 169.6 1.6 104-84.8 190.4-190.4 190.4zM582.4 262.4c17.6 0 32-14.4 32-32v-128c0-17.6-14.4-32-32-32s-32 14.4-32 32v128c0 17.6 14.4 32 32 32zM262.4 582.4c0-17.6-14.4-32-32-32h-128c-17.6 0-32 14.4-32 32s14.4 32 32 32h128c17.6 0 32-14.4 32-32zM310.4 356.8c6.4 6.4 14.4 9.6 22.4 9.6 8 0 16-3.2 22.4-9.6 12.8-12.8 12.8-32 0-44.8l-91.2-91.2c-12.8-12.8-32-12.8-44.8 0-12.8 12.8-12.8 32 0 44.8l91.2 91.2zM944 220.8c-12.8-12.8-32-12.8-44.8 0l-91.2 91.2c-12.8 12.8-12.8 32 0 44.8 6.4 6.4 14.4 9.6 22.4 9.6 8 0 16-3.2 22.4-9.6l91.2-91.2c12.8-12.8 12.8-33.6 0-44.8zM310.4 808l-91.2 91.2c-12.8 12.8-12.8 32 0 44.8 6.4 6.4 14.4 9.6 22.4 9.6 8 0 16-3.2 22.4-9.6l91.2-91.2c12.8-12.8 12.8-32 0-44.8-11.2-11.2-32-11.2-44.8 0z"
+                    fill="currentColor" fill-rule="evenodd">
+                </path>
+            </svg>
         </a>
     </div>
 </footer>

--- a/theme.yaml
+++ b/theme.yaml
@@ -2,10 +2,6 @@ apiVersion: theme.halo.run/v1alpha1
 kind: Theme
 metadata:
   name: theme-stellar
-  annotations:
-    # Add supports for Halo App Store
-    # https://www.halo.run/store/apps/app-KxJeQ
-    "store.halo.run/app-id": "app-KxJeQ"
 spec:
   customTemplates:
     page:
@@ -34,4 +30,3 @@ spec:
   license:
     - name: "MIT license"
       url: "https://github.com/chengzhongxue/halo-theme-stellar/blob/main/LICENSE"
-  


### PR DESCRIPTION
## 功能描述

添加了主题切换功能，让用户可以方便地切换网站主题。

## 具体更改

- 在设置中添加主题切换按钮的显示控制选项
- 在页脚添加主题切换按钮和图标
- 优化主题切换消息的显示格式

## 截图

在页脚中启用该功能：
![image](https://github.com/user-attachments/assets/3df11517-030a-4428-b66c-aa2185abc327)

![image](https://github.com/user-attachments/assets/293478d1-8629-4ae3-beb7-a13e465b76a3)


close #9 

